### PR TITLE
fix: production.rbのメーラー設定エラーを解決

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,7 +96,7 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   # Devise and Mail settings for production
-  site_url = ApplicationConfig.get('system.site_url', 'https://localhost')
+  site_url = ApplicationConfig.get("system.site_url", "https://localhost")
   uri = URI.parse(site_url)
 
   config.action_mailer.default_url_options = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,10 +96,13 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   # Devise and Mail settings for production
+  site_url = ApplicationConfig.get('system.site_url', 'https://localhost')
+  uri = URI.parse(site_url)
+
   config.action_mailer.default_url_options = {
-    host: Settings.mailer.host,
-    port: Settings.mailer.port,
-    protocol: Settings.mailer.protocol
+    host: uri.host,
+    port: uri.port,
+    protocol: uri.scheme
   }
 
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,7 +98,8 @@ Rails.application.configure do
   # Devise and Mail settings for production
   config.action_mailer.default_url_options = {
     host: Settings.mailer.host,
-    port: Settings.mailer.port
+    port: Settings.mailer.port,
+    protocol: Settings.mailer.protocol
   }
 
   config.action_mailer.delivery_method = :smtp

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,6 +63,17 @@ redis:
   pool_timeout: <%= ENV.fetch('REDIS_POOL_TIMEOUT', '5').to_i %>
 
 # =================================================================
+# メーラー設定（Devise URL生成用）
+# =================================================================
+mailer:
+  # アプリケーションホスト（環境変数: APPLICATION_HOST）
+  host: <%= ENV.fetch('APPLICATION_HOST', 'localhost') %>
+  # ポート（環境変数: APPLICATION_PORT）
+  port: <%= ENV.fetch('APPLICATION_PORT', '80').to_i %>
+  # プロトコル（環境変数: APPLICATION_PROTOCOL）
+  protocol: <%= ENV.fetch('APPLICATION_PROTOCOL', 'http') %>
+
+# =================================================================
 # アプリケーション設定
 # =================================================================
 app:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -63,17 +63,6 @@ redis:
   pool_timeout: <%= ENV.fetch('REDIS_POOL_TIMEOUT', '5').to_i %>
 
 # =================================================================
-# メーラー設定（Devise URL生成用）
-# =================================================================
-mailer:
-  # アプリケーションホスト（環境変数: APPLICATION_HOST）
-  host: <%= ENV.fetch('APPLICATION_HOST', 'localhost') %>
-  # ポート（環境変数: APPLICATION_PORT）
-  port: <%= ENV.fetch('APPLICATION_PORT', '80').to_i %>
-  # プロトコル（環境変数: APPLICATION_PROTOCOL）
-  protocol: <%= ENV.fetch('APPLICATION_PROTOCOL', 'http') %>
-
-# =================================================================
 # アプリケーション設定
 # =================================================================
 app:


### PR DESCRIPTION
## Summary
- Dockerビルド時にproduction.rbで発生していた`Settings.mailer.host`エラーを解決
- 既存の統一設定システム(`system.site_url`)を使用してメーラーURL設定を修正
- RuboCop違反も修正

## Changes
- `config/environments/production.rb`: `ApplicationConfig.get("system.site_url")`を使用
- URI.parseでhost/port/protocolを適切に分解
- 統一設定システムとの整合性を保持

## Test plan
- [x] Docker本番イメージのビルドが成功することを確認
- [x] RuboCop違反が解消されることを確認
- [x] 既存の設定システムとの整合性を確認

🤖 Generated with [Claude Code](https://claude.ai/code)