### PR TITLE
fix: Redis設定とDockerビルド時の環境変数問題を解決

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -73,9 +73,20 @@ ENV RAILS_ENV="production" \
 # Bootsnap使用のためのtmpディレクトリ作成
 RUN mkdir -p tmp/cache
 
+# ビルド時の環境変数を受け取る
+ARG DATABASE_HOST=localhost
+ARG DATABASE_PORT=3306
+ARG DATABASE_NAME=dummy
+ARG DATABASE_USER=dummy
+ARG DATABASE_PASSWORD=dummy
+
 # アセットをプリコンパイル（DATABASE_URL不要でプリコンパイル可能にする）
 RUN SECRET_KEY_BASE_DUMMY=1 \
-    DATABASE_URL=sqlite3:///tmp/dummy.sqlite3 \
+    DATABASE_HOST=${DATABASE_HOST:-localhost} \
+    DATABASE_PORT=${DATABASE_PORT:-3306} \
+    DATABASE_NAME=${DATABASE_NAME:-dummy} \
+    DATABASE_USER=${DATABASE_USER:-dummy} \
+    DATABASE_PASSWORD=${DATABASE_PASSWORD:-dummy} \
     EMAIL_FROM_ADDRESS=dummy@example.com \
     EMAIL_SMTP_ADDRESS=smtp.example.com \
     EMAIL_SMTP_PORT=587 \

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,11 +48,11 @@ Rails.application.configure do
 
   # Use Redis for caching and rate limiting in production
   config.cache_store = :redis_cache_store, {
-    url: Settings.redis.url,
-    timeout: Settings.redis.timeout,
+    url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0"),
+    timeout: ENV.fetch("REDIS_TIMEOUT", "5").to_i,
     pool: {
-      size: Settings.redis.pool_size,
-      timeout: Settings.redis.pool_timeout
+      size: ENV.fetch("REDIS_POOL_SIZE", "5").to_i,
+      timeout: ENV.fetch("REDIS_POOL_TIMEOUT", "5").to_i
     }
   }
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,13 @@ services:
       platforms:
         - linux/amd64
         - linux/arm64
+      # ビルド時の環境変数
+      args:
+        - DATABASE_HOST=${DATABASE_HOST}
+        - DATABASE_PORT=${DATABASE_PORT}
+        - DATABASE_NAME=${DATABASE_NAME}
+        - DATABASE_USER=${DATABASE_USER}
+        - DATABASE_PASSWORD=${DATABASE_PASSWORD}
 
     # コンテナ名設定
     container_name: shlink-ui-rails-app


### PR DESCRIPTION
## Summary
- Redis設定でも環境変数を直接使用してアセットプリコンパイルエラーを解決
- Dockerビルド時の環境変数参照問題を修正
- sqlite3エラーを回避するためのデータベース接続設定を改善

## Changes
### Redis設定の修正
- `config/environments/production.rb`: Redis設定で`ENV.fetch`を直接使用

### Dockerビルド環境変数の修正
- `docker-compose.prod.yml`: ビルド時にDATABASE_*環境変数をARGsとして渡す
- `Dockerfile.production`: ARGでビルド時の環境変数を受け取る

## Technical Details
アセットプリコンパイル時に`Settings.redis.*`と`sqlite3`エラーが発生していました。Redis設定を環境変数直接参照に変更し、Dockerビルド時に適切にデータベース接続情報を渡すことで解決しています。

## Test plan
- [x] Docker本番イメージのビルドが成功することを確認
- [x] アセットプリコンパイルが正常に完了することを確認
- [x] Redis設定が正しく動作することを確認
- [x] データベース接続エラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)