### PR TITLE
fix: アセットプリコンパイル時のデータベースイニシャライザーをスキップ

### DIFF
--- a/config/initializers/database_performance.rb
+++ b/config/initializers/database_performance.rb
@@ -1,22 +1,25 @@
 # Database performance configuration using SystemSetting
 
-Rails.application.reloader.to_prepare do
-  if defined?(SystemSetting) && defined?(ActiveRecord::Base)
-    begin
-      # データベースタイムアウト設定をSystemSettingから取得
-      timeout_seconds = SystemSetting.get("performance.database_timeout", 30)
+# アセットプリコンパイル時はスキップ
+unless ENV["RAILS_GROUPS"] == "assets"
+  Rails.application.reloader.to_prepare do
+    if defined?(SystemSetting) && defined?(ActiveRecord::Base)
+      begin
+        # データベースタイムアウト設定をSystemSettingから取得
+        timeout_seconds = SystemSetting.get("performance.database_timeout", 30)
 
-      # MySQLのタイムアウト設定を適用
-      ActiveRecord::Base.connection_pool.with_connection do |conn|
-        # 接続タイムアウト (秒)
-        conn.execute("SET SESSION wait_timeout = #{timeout_seconds}")
-        # 対話タイムアウト (秒)
-        conn.execute("SET SESSION interactive_timeout = #{timeout_seconds}")
+        # MySQLのタイムアウト設定を適用
+        ActiveRecord::Base.connection_pool.with_connection do |conn|
+          # 接続タイムアウト (秒)
+          conn.execute("SET SESSION wait_timeout = #{timeout_seconds}")
+          # 対話タイムアウト (秒)
+          conn.execute("SET SESSION interactive_timeout = #{timeout_seconds}")
+        end
+
+        Rails.logger.info "Database timeout configured: #{timeout_seconds} seconds"
+      rescue => e
+        Rails.logger.warn "Failed to configure database timeout from SystemSetting: #{e.message}"
       end
-
-      Rails.logger.info "Database timeout configured: #{timeout_seconds} seconds"
-    rescue => e
-      Rails.logger.warn "Failed to configure database timeout from SystemSetting: #{e.message}"
     end
   end
 end


### PR DESCRIPTION
## Summary
- アセットプリコンパイル時にデータベースイニシャライザーが実行されてエラーになる問題を解決
- `RAILS_GROUPS=assets`の時は`database_performance.rb`をスキップするよう修正

## Problem
Dockerビルド時のアセットプリコンパイルで以下のエラーが発生していました：
```
ActiveRecord::ConnectionNotEstablished: No connection pool for 'ActiveRecord::Base'
```

## Root Cause
`config/initializers/database_performance.rb`がアセットプリコンパイル時にも実行され、`SystemSetting.get()`でデータベースアクセスを試行していました。

## Solution
- アセットプリコンパイル時（`RAILS_GROUPS=assets`）はイニシャライザー全体をスキップ
- 本番実行時は正常にデータベースパフォーマンス設定が適用される

## Test plan
- [x] Docker本番イメージのビルドが成功することを確認
- [x] アセットプリコンパイルが正常に完了することを確認
- [x] 本番実行時にデータベース設定が正しく適用されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)