### PR TITLE
fix: アセットプリコンパイル時のnulldb adapter使用によるビルド修正

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -75,10 +75,10 @@ RUN mkdir -p tmp/cache
 
 # アセットをプリコンパイル（データベース接続を無効化）
 RUN SECRET_KEY_BASE_DUMMY=1 \
-    RAILS_GROUPS=assets \
-    DATABASE_URL="" \
-    REDIS_URL="" \
-    ./bin/rails assets:precompile
+    RAILS_ENV=production \
+    DATABASE_URL=nulldb://localhost/dummy \
+    REDIS_URL=redis://localhost:6379/0 \
+    bundle exec rake assets:precompile RAILS_GROUPS=assets
 
 # Bootsnap cache precompile
 RUN bundle exec bootsnap precompile app/ lib/


### PR DESCRIPTION
## Summary
- Docker build時のアセットプリコンパイルでデータベース接続エラーを回避
- nulldb adapterを使用してダミーデータベース環境を構築
- production環境のメール・Redis設定を条件付きで適用

## Changes
- `Dockerfile.production`: DATABASE_URL=nulldb://localhost/dummy を使用
- `config/environments/production.rb`: RAILS_GROUPS=assets時はRedis/メール設定をスキップ  
- `config/initializers/database_performance.rb`: アセット時はDB設定をスキップ

## Test plan
- Docker buildが正常に完了することを確認
- プリコンパイルされたアセットが正常に生成されることを確認
- 本番環境での動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)