### PR TITLE
fix: アセットプリコンパイル時の環境変数読み込み修正

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -73,12 +73,14 @@ ENV RAILS_ENV="production" \
 # Bootsnap使用のためのtmpディレクトリ作成
 RUN mkdir -p tmp/cache
 
-# アセットをプリコンパイル（データベース接続を無効化）
-RUN SECRET_KEY_BASE_DUMMY=1 \
+# 環境変数ファイルをコピー
+COPY .env.production .
+
+# アセットをプリコンパイル（.env.productionから環境変数を読み込み）
+RUN export $(cat .env.production | xargs) && \
+    SECRET_KEY_BASE_DUMMY=1 \
     RAILS_ENV=production \
-    DATABASE_URL=nulldb://localhost/dummy \
-    REDIS_URL=redis://localhost:6379/0 \
-    bundle exec rake assets:precompile RAILS_GROUPS=assets
+    bundle exec rake assets:precompile
 
 # Bootsnap cache precompile
 RUN bundle exec bootsnap precompile app/ lib/


### PR DESCRIPTION
## Summary
- アセットプリコンパイル時に.env.productionから環境変数を読み込み
- 実際のDB接続情報を使用してSystemSettingやApplicationConfigが正常動作
- ハードコーディングを排除して本番設定を適切に利用

## Changes
- `Dockerfile.production`: .env.productionをコピーして環境変数を読み込み
- アセットプリコンパイル時に実際のDB・Redis接続情報を使用

## Test plan
- Docker buildが正常に完了することを確認
- アセットプリコンパイルでSystemSetting等のDB依存処理が動作することを確認
- 本番環境での起動に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)