### PR TITLE
fix: .env.productionコメント行フィルタリング修正

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -77,7 +77,7 @@ RUN mkdir -p tmp/cache
 COPY .env.production .
 
 # アセットをプリコンパイル（.env.productionから環境変数を読み込み）
-RUN export $(cat .env.production | xargs) && \
+RUN export $(cat .env.production | grep -v '^#' | grep -v '^$' | xargs) && \
     SECRET_KEY_BASE_DUMMY=1 \
     RAILS_ENV=production \
     bundle exec rake assets:precompile


### PR DESCRIPTION
## Summary
- .env.productionファイルのコメント行(#)と空行をフィルタリング
- export時の`/bin/sh: export: #: bad variable name`エラーを修正
- アセットプリコンパイル時の環境変数読み込みを正常化

## Changes
- `Dockerfile.production`: `grep -v '^#' | grep -v '^$'`でコメントと空行を除外

## Test plan
- Dockerビルドでexportエラーが発生しないことを確認
- アセットプリコンパイルが正常完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)