### PR TITLE
fix: tmpディレクトリの権限問題修正

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -103,8 +103,8 @@ ENV RAILS_ENV="production" \
     RAILS_LOG_TO_STDOUT="true"
 
 # 必要なディレクトリの権限設定
-RUN mkdir -p /app/tmp /app/log && \
-    chown -R rails:rails /app/tmp /app/log
+RUN mkdir -p /app/tmp/cache /app/tmp/pids /app/log /app/storage && \
+    chown -R rails:rails /app/tmp /app/log /app/storage
 
 # ヘルスチェック用エンドポイント設定
 HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \


### PR DESCRIPTION
## Summary
- tmp/cache, tmp/pids, storageディレクトリの権限問題を修正
- railsユーザーに適切な権限を付与
- `Permission denied @ dir_s_mkdir - /app/tmp/cache`エラーを解決

## Changes
- `Dockerfile.production`: tmp/cache等のディレクトリを明示的に作成・権限付与

## Test plan
- Dockerコンテナ起動時にPermission Deniedエラーが発生しないことを確認
- Railsアプリケーションが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)