### PR TITLE
fix: ActionCableアダプターをRedisに変更

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -9,9 +9,6 @@ test:
   adapter: test
 
 production:
-  adapter: solid_cable
-  connects_to:
-    database:
-      writing: cable
-  polling_interval: 0.1.seconds
-  message_retention: 1.day
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL", "redis://localhost:6379/1") %>
+  channel_prefix: shlink_ui_rails_production


### PR DESCRIPTION
## Summary
- config/cable.ymlのproduction設定をsolid_cableからredisアダプターに変更
- WebSocketが不要なのでRedisを使用してSolid Cableの依存関係を排除
- Solid CableのDB設定エラーを根本的に解決

## Changes
- `config/cable.yml`: production環境でredisアダプターを使用
- REDIS_URLを参照してRedis接続を設定

## Test plan
- アプリケーション起動時にSolid Cableエラーが発生しないことを確認
- ActionCableがRedisを通じて正常動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)