### PR TITLE
fix: Solid Queue用のqueue database設定を追加

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -76,3 +76,11 @@ production:
   password: <%= ENV["DATABASE_PASSWORD"] %>
   host: <%= ENV["DATABASE_HOST"] || "localhost" %>
   port: <%= ENV["DATABASE_PORT"] || 3306 %>
+
+queue:
+  <<: *default
+  database: <%= ENV["DATABASE_NAME"] || "shlink_ui_rails_production" %>
+  username: <%= ENV["DATABASE_USER"] || "app" %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>
+  host: <%= ENV["DATABASE_HOST"] || "localhost" %>
+  port: <%= ENV["DATABASE_PORT"] || 3306 %>


### PR DESCRIPTION
## Summary
- Solid Queueが要求する`queue` database設定をdatabase.ymlに追加
- production環境で同一データベースを使用する設定

## Test plan
- [ ] Dockerイメージの再ビルド確認
- [ ] Rails起動エラーの解消確認

🤖 Generated with [Claude Code](https://claude.ai/code)