### PR TITLE
fix: Solid Queueを同一データベースに設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,7 @@ Rails.application.configure do
   # Replace the default in-process and non-durable queuing backend for Active Job (skip during assets precompile)
   unless ENV["RAILS_GROUPS"] == "assets"
     config.active_job.queue_adapter = :solid_queue
-    config.solid_queue.connects_to = { database: { writing: :queue } }
+    config.solid_queue.connects_to = { database: { writing: :production } }
   end
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
## Summary
- production環境でSolid Queueがproductionデータベースを使用するよう修正
- queueデータベース設定エラーを解決

🤖 Generated with [Claude Code](https://claude.ai/code)