### PR TITLE
fix: 不要なqueue database設定を削除

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -76,11 +76,3 @@ production:
   password: <%= ENV["DATABASE_PASSWORD"] %>
   host: <%= ENV["DATABASE_HOST"] || "localhost" %>
   port: <%= ENV["DATABASE_PORT"] || 3306 %>
-
-queue:
-  <<: *default
-  database: <%= ENV["DATABASE_NAME"] || "shlink_ui_rails_production" %>
-  username: <%= ENV["DATABASE_USER"] || "app" %>
-  password: <%= ENV["DATABASE_PASSWORD"] %>
-  host: <%= ENV["DATABASE_HOST"] || "localhost" %>
-  port: <%= ENV["DATABASE_PORT"] || 3306 %>


### PR DESCRIPTION
## Summary
- database.ymlから不要なqueue設定を削除
- Solid Queueはproductionデータベースを使用するため設定不要

## Test plan
- [ ] Dockerイメージ再ビルド
- [ ] Rails起動確認

🤖 Generated with [Claude Code](https://claude.ai/code)