### PR TITLE
fix: Solid Queue設定をシンプル化

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,6 @@ Rails.application.configure do
   # Replace the default in-process and non-durable queuing backend for Active Job (skip during assets precompile)
   unless ENV["RAILS_GROUPS"] == "assets"
     config.active_job.queue_adapter = :solid_queue
-    config.solid_queue.connects_to = { database: { writing: :production } }
   end
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
## Summary
- connects_to設定を削除してqueue databaseエラーを解決
- developmentと同様のシンプルな設定に統一

## Test plan
- [ ] Dockerイメージ再ビルド
- [ ] Rails起動確認

🤖 Generated with [Claude Code](https://claude.ai/code)