### PR TITLE
fix: production.rbにconnects_to設定を復元

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,7 @@ Rails.application.configure do
   # Replace the default in-process and non-durable queuing backend for Active Job (skip during assets precompile)
   unless ENV["RAILS_GROUPS"] == "assets"
     config.active_job.queue_adapter = :solid_queue
+    config.solid_queue.connects_to = { database: { writing: :queue } }
   end
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
## Summary
- Rails 8 Solid Queueに必要なconnects_to設定を復元
- database.ymlのqueue設定と組み合わせて正常動作

## Test plan
- [ ] Dockerイメージ再ビルド
- [ ] Rails起動確認

🤖 Generated with [Claude Code](https://claude.ai/code)