### PR TITLE
fix: database.ymlにcache設定を追加

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -84,3 +84,11 @@ queue:
   password: <%= ENV["DATABASE_PASSWORD"] %>
   host: <%= ENV["DATABASE_HOST"] || "localhost" %>
   port: <%= ENV["DATABASE_PORT"] || 3306 %>
+
+cache:
+  <<: *default
+  database: <%= ENV["DATABASE_NAME"] || "shlink_ui_rails_production" %>
+  username: <%= ENV["DATABASE_USER"] || "app" %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>
+  host: <%= ENV["DATABASE_HOST"] || "localhost" %>
+  port: <%= ENV["DATABASE_PORT"] || 3306 %>


### PR DESCRIPTION
## Summary
- Solid Cacheが要求するcache database設定を追加
- queue設定と同じく同一データベースを使用

## Test plan
- [ ] Dockerイメージ再ビルド
- [ ] Rails起動確認

🤖 Generated with [Claude Code](https://claude.ai/code)