### PR TITLE
fix: production環境でCSP nonceを無効化

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -25,10 +25,6 @@ Rails.application.configure do
 
   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  # Development環境ではnonce無効化（unsafe-inlineを有効にするため）
-  unless Rails.env.production?
-    config.content_security_policy_nonce_directives = %w[]
-  else
-    config.content_security_policy_nonce_directives = %w[script-src style-src]
-  end
+  # All環境でnonce無効化（unsafe-inlineを有効にするため）
+  config.content_security_policy_nonce_directives = %w[]
 end


### PR DESCRIPTION
## Summary
- production環境でnonce directives を無効化
- インラインスタイル/スクリプトのCSPエラーを解決
- unsafe-inlineを有効にしてTurbo等の動作を正常化

## Test plan
- [ ] Dockerイメージ再ビルド
- [ ] CSPエラーの解消確認

🤖 Generated with [Claude Code](https://claude.ai/code)