### PR TITLE
fix: CSP nonce_generatorを完全に無効化

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
   end
 
   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  # config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
   # All環境でnonce無効化（unsafe-inlineを有効にするため）
   config.content_security_policy_nonce_directives = %w[]
 end


### PR DESCRIPTION
## Summary
- nonce_generatorをコメントアウトして完全に無効化
- nonce生成を停止してunsafe-inlineを有効化
- TurboのCSPエラーを解決

## Test plan
- [ ] Dockerイメージ再ビルド
- [ ] CSPエラーの完全解消確認

🤖 Generated with [Claude Code](https://claude.ai/code)