### PR TITLE
fix: Ruby 3.4対応でnet-smtp gemを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,9 @@ gem "redis"
 # MailerSend API for email delivery (production)
 gem "mailersend-ruby"
 
+# Ruby 3.4 compatibility for SMTP
+gem "net-smtp", require: false
+
 # Two-Factor Authentication
 gem "rotp"        # TOTP generation and verification
 gem "rqrcode"     # QR code generation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -607,6 +607,7 @@ DEPENDENCIES
   letter_opener_web
   mailersend-ruby
   mysql2 (~> 0.5)
+  net-smtp
   omniauth
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,4 +1,4 @@
-require 'net/smtp'
+require "net/smtp"
 
 class Admin::SettingsController < Admin::AdminController
   def show

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,3 +1,5 @@
+require 'net/smtp'
+
 class Admin::SettingsController < Admin::AdminController
   def show
     @settings_by_category = SystemSetting.enabled


### PR DESCRIPTION
## Summary
- Ruby 3.4でNet::SMTPConnectError未定義エラーを解決
- net-smtp gemを明示的に追加

## Test plan
- [ ] bundle installとDockerイメージ再ビルド
- [ ] SMTPエラーの解消確認

🤖 Generated with [Claude Code](https://claude.ai/code)