### PR TITLE
fix: Net::SMTPConnectError を適切なエラークラスに修正

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -169,7 +169,7 @@ class Admin::SettingsController < Admin::AdminController
         "詳細メッセージ" => error_details[:details]
       }
     }
-  rescue Net::SMTPConnectError => e
+  rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENOTFOUND, IOError, EOFError => e
     error_details = {
       error_type: "接続エラー",
       server: "#{smtp_settings[:address]}:#{smtp_settings[:port]}",


### PR DESCRIPTION
## Summary
- 存在しない `Net::SMTPConnectError` を標準的なエラークラスに修正
- SMTP接続エラーの適切なハンドリングを実装

## Changes
- `Net::SMTPConnectError` → `Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENOTFOUND, IOError, EOFError`
- Ruby標準ライブラリの実在するエラークラスに置き換え

## Test plan
- [ ] SMTP設定テストで接続エラーが適切にキャッチされる
- [ ] エラー詳細情報が正しく表示される
- [ ] 500エラーが発生しない

🤖 Generated with [Claude Code](https://claude.ai/code)