### PR TITLE
fix: Solid Queueジョブコンテナのコマンドを./bin/jobsに修正

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -78,7 +78,7 @@ services:
     restart: unless-stopped
 
     # ジョブ処理コマンド実行
-    command: bundle exec solid_queue
+    command: ./bin/jobs
 
     # 環境変数ファイル読み込み
     env_file:


### PR DESCRIPTION
## Summary
- bundle exec solid_queueでは"command not found"エラーが発生していた問題を修正
- 正しいbin/jobsスクリプトを使用するよう変更
- これによりjobsコンテナが正常に起動可能

## Test plan
- [ ] docker-compose -f docker-compose.prod.yml up -d でjobsコンテナが正常起動することを確認
- [ ] jobsコンテナのログにエラーが出ないことを確認
- [ ] appコンテナとjobsコンテナ両方がHealthy/Startedになることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)