### PR TITLE
fix: production環境のSolid Queue設定にschedulersを追加

### DIFF
--- a/config/solid_queue.yml
+++ b/config/solid_queue.yml
@@ -27,3 +27,5 @@ production:
     - queues: "*"
       threads: 3
       processes: 2
+  schedulers:
+    - recurring_tasks: true


### PR DESCRIPTION
- recurring_tasksを使用するためにはschedulersの設定が必要
- production環境にschedulers: recurring_tasks: trueを追加
- これによりjobsコンテナの起動エラーが解決される

🤖 Generated with [Claude Code](https://claude.ai/code)