### PR TITLE
feat: Solid Queueのrecurring_tasksテーブルスキーマを追加

### DIFF
--- a/db/schemas/Schemafile
+++ b/db/schemas/Schemafile
@@ -253,3 +253,20 @@ end
 
 add_index "solid_queue_processes", [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
 add_index "solid_queue_processes", [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
+
+create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+  t.string "key", null: false
+  t.string "schedule", null: false
+  t.string "command", limit: 2048
+  t.string "class_name"
+  t.text "arguments"
+  t.string "queue_name"
+  t.integer "priority", default: 0
+  t.boolean "static", default: true, null: false
+  t.text "description"
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+end
+
+add_index "solid_queue_recurring_tasks", [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
+add_index "solid_queue_recurring_tasks", [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true


### PR DESCRIPTION
## Summary
- recurring tasksを使用するために必要な`solid_queue_recurring_tasks`テーブルをSchemafileに追加
- Solid Queue 1.2.1で必要な全フィールド（key, schedule, command, class_name等）とインデックスを含む
- これによりjobsコンテナでのrecurring tasksエラーが解決される

## Background
jobsコンテナで`Table 'shlink_ui_rails_production.solid_queue_recurring_tasks' doesn't exist`エラーが発生していた。Solid Queue 1.2.1でrecurring_tasksを使用するにはこのテーブルが必要。

## Test plan
- [ ] Schemafileの構文が正しいことを確認
- [ ] Ridgepoleでのスキーマ適用が成功することを確認
- [ ] jobsコンテナが正常に起動することを確認
- [ ] recurring tasksが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)