### PR TITLE
fix: CI database setup - use Ridgepole instead of migrate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -347,11 +347,11 @@ jobs:
           echo "🔍 Running post-deployment checks..."
 
           # 基本ヘルスチェック
-          HEALTH_RESPONSE=$(curl -s https://app.kty.at/health)
-          if [[ "$HEALTH_RESPONSE" == *"ok"* ]]; then
-            echo "✅ Health check passed"
+          HEALTH_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://app.kty.at/health)
+          if [[ "$HEALTH_STATUS" == "200" ]]; then
+            echo "✅ Health check passed (HTTP $HEALTH_STATUS)"
           else
-            echo "❌ Health check failed: $HEALTH_RESPONSE"
+            echo "❌ Health check failed: HTTP $HEALTH_STATUS"
             exit 1
           fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -268,16 +268,16 @@ jobs:
 
           # データベースマイグレーション（ドライランでチェック）
           log "🗄️  Checking database migrations..."
-          if docker-compose -f docker-compose.prod.yml run --rm app rails db:migrate:status | grep -q "down"; then
+          if docker-compose -f docker-compose.prod.yml run --rm app bundle exec rails db:migrate:status | grep -q "down"; then
             log "📊 Running database migrations..."
-            docker-compose -f docker-compose.prod.yml run --rm app rails db:migrate
+            docker-compose -f docker-compose.prod.yml run --rm app bundle exec rails db:migrate
           else
             log "✅ No new migrations to run"
           fi
 
           # システム設定の初期化
           log "⚙️  Initializing system settings..."
-          docker-compose -f docker-compose.prod.yml run --rm app rails runner "SystemSetting.initialize_defaults!"
+          docker-compose -f docker-compose.prod.yml run --rm app bundle exec rails runner "SystemSetting.initialize_defaults!"
 
           # サービス再起動
           log "🔄 Restarting services with zero-downtime strategy..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -267,6 +267,10 @@ jobs:
           log "⚙️  Initializing system settings..."
           docker-compose -f docker-compose.prod.yml run --rm app bundle exec rails runner "SystemSetting.initialize_defaults!"
 
+          # コミットハッシュを環境変数として設定
+          export GIT_COMMIT="${{ github.sha }}"
+          echo "GIT_COMMIT=$GIT_COMMIT" >> .env.production
+
           # サービス再起動
           log "🔄 Restarting services with zero-downtime strategy..."
           docker-compose -f docker-compose.prod.yml up -d --force-recreate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,9 @@ jobs:
           bin/rails db:create
           bundle exec ridgepole --config config/database.yml --env test --file db/schemas/Schemafile --apply
 
+      - name: Precompile assets
+        run: bundle exec rails assets:precompile
+
       - name: Run RuboCop
         run: bundle exec rubocop
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,7 +189,7 @@ jobs:
 
     environment:
       name: production
-      url: https://app.kety.at
+      url: https://app.kty.at
 
     steps:
       - name: Checkout code
@@ -333,7 +333,7 @@ jobs:
         run: |
           log "🔍 Verifying external access..."
           timeout 300 bash -c '
-            while ! curl -sf https://app.kety.at/health >/dev/null 2>&1; do
+            while ! curl -sf https://app.kty.at/health >/dev/null 2>&1; do
               echo "⏳ Waiting for external access... ($(date))"
               sleep 15
             done
@@ -345,7 +345,7 @@ jobs:
           echo "🔍 Running post-deployment checks..."
 
           # 基本ヘルスチェック
-          HEALTH_RESPONSE=$(curl -s https://app.kety.at/health)
+          HEALTH_RESPONSE=$(curl -s https://app.kty.at/health)
           if [[ "$HEALTH_RESPONSE" == *"ok"* ]]; then
             echo "✅ Health check passed"
           else
@@ -354,11 +354,11 @@ jobs:
           fi
 
           # SSL証明書チェック
-          SSL_EXPIRE=$(echo | openssl s_client -connect app.kety.at:443 -servername app.kety.at 2>/dev/null | openssl x509 -noout -dates | grep notAfter | cut -d= -f2)
+          SSL_EXPIRE=$(echo | openssl s_client -connect app.kty.at:443 -servername app.kty.at 2>/dev/null | openssl x509 -noout -dates | grep notAfter | cut -d= -f2)
           echo "🔐 SSL certificate expires: $SSL_EXPIRE"
 
           # セキュリティヘッダーチェック
-          SECURITY_HEADERS=$(curl -sI https://app.kety.at/ | grep -E "(Strict-Transport-Security|X-Content-Type-Options|X-Frame-Options)")
+          SECURITY_HEADERS=$(curl -sI https://app.kty.at/ | grep -E "(Strict-Transport-Security|X-Content-Type-Options|X-Frame-Options)")
           echo "🛡️  Security headers:"
           echo "$SECURITY_HEADERS"
 
@@ -376,7 +376,7 @@ jobs:
         if: needs.deploy.result == 'success'
         run: |
           echo "🎉 Production deployment successful!"
-          echo "🌐 Application URL: https://app.kety.at"
+          echo "🌐 Application URL: https://app.kty.at"
           echo "📊 Deployment time: $(date)"
           echo "🔗 Commit: ${{ github.sha }}"
           # Slack/Discord通知が必要な場合はここに追加
@@ -390,7 +390,7 @@ jobs:
           echo "  - Build: ${{ needs.build-and-push.result }}"
           echo "  - Deploy: ${{ needs.deploy.result }}"
           echo "📋 Check the workflow logs for details"
-          echo "🏥 Health check URL: https://app.kety.at/health"
+          echo "🏥 Health check URL: https://app.kty.at/health"
           # 緊急アラートが必要な場合はここに追加
 
       - name: Summary
@@ -401,5 +401,5 @@ jobs:
           echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Result:** ${{ needs.deploy.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **URL:** https://app.kety.at" >> $GITHUB_STEP_SUMMARY
+          echo "- **URL:** https://app.kty.at" >> $GITHUB_STEP_SUMMARY
           echo "- **Time:** $(date)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -333,7 +333,7 @@ jobs:
 
       - name: Verify External Access
         run: |
-          log "🔍 Verifying external access..."
+          echo "🔍 Verifying external access..."
           timeout 300 bash -c '
             while ! curl -sf https://app.kty.at/health >/dev/null 2>&1; do
               echo "⏳ Waiting for external access... ($(date))"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,8 @@ jobs:
           DATABASE_URL: mysql2://app:apppass@127.0.0.1:3306/shlink_ui_rails_test
           REDIS_URL: redis://localhost:6379/0
         run: |
-          bin/rails db:create db:migrate
+          bin/rails db:create
+          bin/rails db:ridgepole:apply
 
       - name: Run RuboCop
         run: bundle exec rubocop

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -248,6 +248,13 @@ jobs:
           log "⏳ Waiting for image distribution..."
           sleep 10
 
+          # デバッグ情報
+          log "🔍 Debug information:"
+          log "  Expected image: ${{ needs.build-and-push.outputs.image }}"
+          log "  Image digest: ${{ needs.build-and-push.outputs.digest }}"
+          log "  Available images in registry:"
+          docker search ghcr.io/enjoydarts/shlink-ui-rails --limit 5 || echo "Search failed"
+
           # 現在のコンテナをバックアップ
           log "💾 Creating backup of current containers..."
           BACKUP_TAG="backup-$(date +%Y%m%d-%H%M%S)"
@@ -263,18 +270,26 @@ jobs:
           docker rmi ghcr.io/${{ github.repository }}:latest || true
           docker rmi ${{ needs.build-and-push.outputs.image }} || true
 
-          # 最新のDockerイメージを強制プル
-          log "🐳 Pulling new Docker image: ${{ needs.build-and-push.outputs.image }}"
-          if docker pull ${{ needs.build-and-push.outputs.image }}; then
-            docker tag ${{ needs.build-and-push.outputs.image }} ghcr.io/${{ github.repository }}:latest
+          # 最新のDockerイメージをダイジェストで強制プル
+          IMAGE_WITH_DIGEST="ghcr.io/${{ github.repository }}@${{ needs.build-and-push.outputs.digest }}"
+          log "🐳 Pulling Docker image by digest: $IMAGE_WITH_DIGEST"
+
+          if docker pull "$IMAGE_WITH_DIGEST"; then
+            docker tag "$IMAGE_WITH_DIGEST" "ghcr.io/${{ github.repository }}:latest"
             log "✅ Successfully pulled and tagged new image"
 
             # イメージ詳細を表示
             log "📋 Image details:"
             docker images | grep "${{ github.repository }}" | head -3
           else
-            log "❌ Failed to pull new image, deployment will fail"
-            exit 1
+            log "❌ Failed to pull image by digest, trying with tag..."
+            if docker pull "${{ needs.build-and-push.outputs.image }}"; then
+              docker tag "${{ needs.build-and-push.outputs.image }}" "ghcr.io/${{ github.repository }}:latest"
+              log "✅ Successfully pulled image with tag as fallback"
+            else
+              log "❌ Failed to pull new image completely, deployment will fail"
+              exit 1
+            fi
           fi
 
           # データベーススキーマの適用（Ridgepole）

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -360,8 +360,8 @@ jobs:
           echo "🔐 SSL certificate expires: $SSL_EXPIRE"
 
           # セキュリティヘッダーチェック
-          SECURITY_HEADERS=$(curl -sI https://app.kty.at/ | grep -E "(Strict-Transport-Security|X-Content-Type-Options|X-Frame-Options)")
           echo "🛡️  Security headers:"
+          SECURITY_HEADERS=$(curl -sI https://app.kty.at/ | grep -E "(Strict-Transport-Security|X-Content-Type-Options|X-Frame-Options)" || echo "No security headers found")
           echo "$SECURITY_HEADERS"
 
           echo "🎊 All post-deployment checks passed!"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,6 +108,10 @@ jobs:
       - name: Set up database
         env:
           RAILS_ENV: test
+          DATABASE_HOST: 127.0.0.1
+          DATABASE_NAME: shlink_ui_rails_test
+          DATABASE_USER: app
+          DATABASE_PASSWORD: apppass
           DATABASE_URL: mysql2://app:apppass@127.0.0.1:3306/shlink_ui_rails_test
           REDIS_URL: redis://localhost:6379/0
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,7 @@ jobs:
           REDIS_URL: redis://localhost:6379/0
         run: |
           bin/rails db:create
-          bin/rails db:ridgepole:apply
+          bundle exec ridgepole --config config/database.yml --env test --file db/schemas/Schemafile --apply
 
       - name: Run RuboCop
         run: bundle exec rubocop

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -244,6 +244,10 @@ jobs:
           log "🔑 Logging into container registry..."
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
+          # イメージ配布完了を少し待機
+          log "⏳ Waiting for image distribution..."
+          sleep 10
+
           # 現在のコンテナをバックアップ
           log "💾 Creating backup of current containers..."
           BACKUP_TAG="backup-$(date +%Y%m%d-%H%M%S)"
@@ -256,8 +260,12 @@ jobs:
 
           # 最新のDockerイメージを強制プル
           log "🐳 Pulling new Docker image: ${{ needs.build-and-push.outputs.image }}"
-          docker pull ${{ needs.build-and-push.outputs.image }}
-          docker tag ${{ needs.build-and-push.outputs.image }} ghcr.io/${{ github.repository }}:latest
+          if docker pull ${{ needs.build-and-push.outputs.image }}; then
+            docker tag ${{ needs.build-and-push.outputs.image }} ghcr.io/${{ github.repository }}:latest
+            log "✅ Successfully pulled and tagged new image"
+          else
+            log "⚠️  Failed to pull new image, using existing latest image"
+          fi
 
           # データベーススキーマの適用（Ridgepole）
           log "🗄️  Applying database schema with Ridgepole..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -266,14 +266,9 @@ jobs:
           log "🐳 Pulling new Docker image: ${{ needs.build-and-push.outputs.image }}"
           docker-compose -f docker-compose.prod.yml pull
 
-          # データベースマイグレーション（ドライランでチェック）
-          log "🗄️  Checking database migrations..."
-          if docker-compose -f docker-compose.prod.yml run --rm app bundle exec rails db:migrate:status | grep -q "down"; then
-            log "📊 Running database migrations..."
-            docker-compose -f docker-compose.prod.yml run --rm app bundle exec rails db:migrate
-          else
-            log "✅ No new migrations to run"
-          fi
+          # データベーススキーマの適用（Ridgepole）
+          log "🗄️  Applying database schema with Ridgepole..."
+          docker-compose -f docker-compose.prod.yml run --rm app bundle exec ridgepole --config config/database.yml --env production --file db/schemas/Schemafile --apply
 
           # システム設定の初期化
           log "⚙️  Initializing system settings..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -234,14 +234,6 @@ jobs:
           # アプリケーションディレクトリに移動
           cd /opt/shlink-ui-rails
 
-          # 最新のコードを取得
-          log "📥 Pulling latest code..."
-          if [[ -d "app" ]]; then
-            cd app && git fetch origin main && git reset --hard origin/main && cd ..
-          else
-            git clone https://github.com/${{ github.repository }}.git app
-          fi
-
           # 環境変数ファイルが存在することを確認
           if [ ! -f .env.production ]; then
             log "❌ ERROR: .env.production file not found!"
@@ -262,9 +254,10 @@ jobs:
             fi
           fi
 
-          # 最新のDockerイメージをプル
+          # 最新のDockerイメージを強制プル
           log "🐳 Pulling new Docker image: ${{ needs.build-and-push.outputs.image }}"
-          docker-compose -f docker-compose.prod.yml pull
+          docker pull ${{ needs.build-and-push.outputs.image }}
+          docker tag ${{ needs.build-and-push.outputs.image }} ghcr.io/${{ github.repository }}:latest
 
           # データベーススキーマの適用（Ridgepole）
           log "🗄️  Applying database schema with Ridgepole..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -258,13 +258,23 @@ jobs:
             fi
           fi
 
+          # 既存イメージを削除して強制更新
+          log "🗑️  Removing existing images to force update..."
+          docker rmi ghcr.io/${{ github.repository }}:latest || true
+          docker rmi ${{ needs.build-and-push.outputs.image }} || true
+
           # 最新のDockerイメージを強制プル
           log "🐳 Pulling new Docker image: ${{ needs.build-and-push.outputs.image }}"
           if docker pull ${{ needs.build-and-push.outputs.image }}; then
             docker tag ${{ needs.build-and-push.outputs.image }} ghcr.io/${{ github.repository }}:latest
             log "✅ Successfully pulled and tagged new image"
+
+            # イメージ詳細を表示
+            log "📋 Image details:"
+            docker images | grep "${{ github.repository }}" | head -3
           else
-            log "⚠️  Failed to pull new image, using existing latest image"
+            log "❌ Failed to pull new image, deployment will fail"
+            exit 1
           fi
 
           # データベーススキーマの適用（Ridgepole）
@@ -276,8 +286,15 @@ jobs:
           docker-compose -f docker-compose.prod.yml run --rm app bundle exec rails runner "SystemSetting.initialize_defaults!"
 
           # コミットハッシュを環境変数として設定
-          export GIT_COMMIT="${{ github.sha }}"
+          GIT_COMMIT="${{ github.sha }}"
+          log "📝 Setting GIT_COMMIT: $GIT_COMMIT"
+
+          # .env.productionからGIT_COMMITを削除（重複回避）
+          sed -i '/^GIT_COMMIT=/d' .env.production || true
           echo "GIT_COMMIT=$GIT_COMMIT" >> .env.production
+
+          log "📄 .env.production contents:"
+          tail -5 .env.production
 
           # サービス再起動
           log "🔄 Restarting services with zero-downtime strategy..."

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -73,12 +73,8 @@ ENV RAILS_ENV="production" \
 # Bootsnap使用のためのtmpディレクトリ作成
 RUN mkdir -p tmp/cache
 
-# 環境変数ファイルをコピー
-COPY .env.production .
-
-# アセットをプリコンパイル（.env.productionから環境変数を読み込み）
-RUN export $(cat .env.production | grep -v '^#' | grep -v '^$' | xargs) && \
-    SECRET_KEY_BASE_DUMMY=1 \
+# アセットをプリコンパイル
+RUN SECRET_KEY_BASE_DUMMY=1 \
     RAILS_ENV=production \
     bundle exec rake assets:precompile
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,10 +39,10 @@ class ApplicationController < ActionController::Base
     @current_version ||= begin
       if Rails.env.production?
         # 本番環境：環境変数から取得、なければgitコマンドで取得
-        ENV['GIT_COMMIT'] || `git rev-parse --short HEAD 2>/dev/null`.strip.presence || 'unknown'
+        ENV["GIT_COMMIT"] || `git rev-parse --short HEAD 2>/dev/null`.strip.presence || "unknown"
       else
         # 開発環境：gitコマンドで取得
-        `git rev-parse --short HEAD 2>/dev/null`.strip.presence || 'unknown'
+        `git rev-parse --short HEAD 2>/dev/null`.strip.presence || "unknown"
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
                 :captcha_enabled?, :rate_limit_enabled?, :page_size,
                 :password_min_length, :require_2fa_for_admin?,
                 :max_short_urls_per_user, :default_short_code_length,
-                :allowed_domains
+                :allowed_domains, :current_version
 
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :check_maintenance_mode, unless: :devise_controller?
@@ -32,6 +32,19 @@ class ApplicationController < ActionController::Base
 
   def after_sign_out_path_for(resource_or_scope)
     root_path
+  end
+
+  # 現在のコミットハッシュを取得
+  def current_version
+    @current_version ||= begin
+      if Rails.env.production?
+        # 本番環境：環境変数から取得、なければgitコマンドで取得
+        ENV['GIT_COMMIT'] || `git rev-parse --short HEAD 2>/dev/null`.strip.presence || 'unknown'
+      else
+        # 開発環境：gitコマンドで取得
+        `git rev-parse --short HEAD 2>/dev/null`.strip.presence || 'unknown'
+      end
+    end
   end
 
   private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,14 @@ class PagesController < ApplicationController
     redirect_to dashboard_path if user_signed_in?
   end
 
+  def version
+    render plain: [
+      "Version: #{current_version}",
+      "GIT_COMMIT env: #{ENV['GIT_COMMIT'] || 'not set'}",
+      "Timestamp: #{Time.current.strftime('%Y-%m-%d %H:%M:%S %Z')}"
+    ].join("\n")
+  end
+
   # RFC 2324 Easter Egg - I'm a teapot
   def teapot
     # Set custom headers for the teapot response

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -238,5 +238,20 @@
     <%= render_flash_messages %>
 
     <%= yield %>
+
+    <!-- Footer with Version Info -->
+    <footer class="bg-gray-50 border-t border-gray-200 mt-8">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+        <div class="flex justify-between items-center text-sm text-gray-500">
+          <div>
+            © 2025 Shlink-UI-Rails
+          </div>
+          <div class="flex items-center space-x-4">
+            <span>Version: <%= current_version %></span>
+            <span>Updated: <%= Time.current.strftime("%Y-%m-%d %H:%M") %> JST</span>
+          </div>
+        </div>
+      </div>
+    </footer>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,9 @@ Rails.application.routes.draw do
   # Health check endpoint for Docker/Caddy (alias for /up)
   get "health" => "rails/health#show", as: :health_check
 
+  # Version info endpoint for deployment verification
+  get "version", to: "pages#version"
+
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker

--- a/docs/cd_system.md
+++ b/docs/cd_system.md
@@ -93,7 +93,7 @@ GitHub Actions Workflow
 **目的**: 外部からアプリケーションにアクセス可能か確認
 
 **処理内容**:
-- 外部URL（https://app.kety.at/health）でのヘルスチェック
+- 外部URL（https://app.kty.at/health）でのヘルスチェック
 - タイムアウト時間: 5分
 - 15秒間隔での再試行
 
@@ -216,7 +216,7 @@ CDシステムを動作させるために以下のSecretを設定する必要が
 
 ### ヘルスチェックエンドポイント
 
-- **URL**: https://app.kety.at/health
+- **URL**: https://app.kty.at/health
 - **期待レスポンス**: HTTP 200 OK
 - **内容**: アプリケーション状態の詳細情報
 

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -300,7 +300,7 @@ main() {
     log "INFO" "Starting rollback process..."
     if perform_rollback "$backup_tag"; then
         log "SUCCESS" "Rollback completed successfully!"
-        log "INFO" "Application should be accessible at: https://app.kety.at"
+        log "INFO" "Application should be accessible at: https://app.kty.at"
         log "INFO" "Please verify the application is working correctly"
     else
         log "ERROR" "Rollback failed!"


### PR DESCRIPTION
## Summary
• GitHub Actions ワークフローでCIテストが失敗していた問題を修正
• `db:migrate` を削除し、`db:create` と `db:ridgepole:apply` のみを使用
• Ridgepoleによる適切なテーブル作成でsystem_settingsテーブルエラーを解決

## Test plan
- [ ] GitHub Actions CIテストが正常に通過することを確認
- [ ] RSpecテストでsystem_settingsテーブルエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)