### PR TITLE
fix: コミットID表示とタイムゾーン問題を修正

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,6 +28,8 @@ services:
       - RAILS_ENV=production
       - RAILS_SERVE_STATIC_FILES=true
       - RAILS_LOG_TO_STDOUT=true
+      - TZ=Asia/Tokyo
+      - GIT_COMMIT=${GIT_COMMIT}
 
     # ボリューム設定（ホストパス指定で管理しやすく）
     volumes:
@@ -84,6 +86,8 @@ services:
     environment:
       - RAILS_ENV=production
       - SOLID_QUEUE_LOG_LEVEL=info
+      - TZ=Asia/Tokyo
+      - GIT_COMMIT=${GIT_COMMIT}
 
     # ボリューム設定（appサービスと共有）
     volumes:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -283,7 +283,7 @@ send_deployment_notification() {
     message+="**環境:** Production (app.kty.at)\n"
     message+="**コミット:** \`$commit_hash\`\n"
     message+="**イメージ:** \`${IMAGE:-latest}\`\n"
-    message+="**時刻:** $(date '+%Y-%m-%d %H:%M:%S JST')\n"
+    message+="**時刻:** $(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M:%S JST')\n"
 
     if [[ "$status" != "success" && -n "$error_message" ]]; then
         message+="\n**エラー:** $error_message"
@@ -377,8 +377,9 @@ main() {
     # ソースコードは既にGitHub Actionsで更新済み
     log "INFO" "Source code already updated by GitHub Actions"
 
-    # 現在のコミットハッシュを表示
+    # 現在のコミットハッシュを取得して環境変数に設定
     local current_commit=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    export GIT_COMMIT="$current_commit"
     log "INFO" "Current commit: $current_commit"
 
     # 現在の状態をバックアップ


### PR DESCRIPTION
フッターのコミットIDが更新されない問題と通知時刻の表示を修正

## 修正内容
1. **コミットID表示修正**
   - デプロイ時にGIT_COMMIT環境変数を設定
   - docker-compose.prod.ymlでコンテナに環境変数を渡すよう設定
   - Rails側で ENV["GIT_COMMIT"] が正しく表示されるように

2. **タイムゾーン修正**
   - コンテナのタイムゾーンをAsia/Tokyoに設定
   - 通知メッセージの時刻表示を明示的にJSTで表示

これでフッターのバージョン表示とデプロイ通知が正常に動作

🤖 Generated with [Claude Code](https://claude.ai/code)