### PR TITLE
feat: 本番環境でファイルログ出力を有効化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 
+# Production logs directory
+/logs/*
+!/logs/.keep
+
 # macOS
 .DS_Store
 .DS_Store?

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,9 +33,22 @@ Rails.application.configure do
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
-  # Log to STDOUT with the current request id as a default log tag.
+  # Log to file with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+
+  # Log to both file and STDOUT for production
+  file_logger = Logger.new(Rails.root.join("logs", "production.log"), "daily")
+  file_logger.level = Logger::INFO
+  file_logger.formatter = Logger::Formatter.new
+
+  stdout_logger = Logger.new(STDOUT)
+  stdout_logger.level = Logger::INFO
+  stdout_logger.formatter = Logger::Formatter.new
+
+  # Combine both loggers
+  config.logger = ActiveSupport::TaggedLogging.new(
+    ActiveSupport::BroadcastLogger.new(file_logger, stdout_logger)
+  )
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,11 +38,9 @@ Rails.application.configure do
 
   # Log to both file and STDOUT for production
   file_logger = Logger.new(Rails.root.join("logs", "production.log"), "daily")
-  file_logger.level = Logger::INFO
   file_logger.formatter = Logger::Formatter.new
 
   stdout_logger = Logger.new(STDOUT)
-  stdout_logger.level = Logger::INFO
   stdout_logger.formatter = Logger::Formatter.new
 
   # Combine both loggers


### PR DESCRIPTION
## Summary
- 本番環境で `/logs` ディレクトリにログファイル出力を追加
- STDOUTとファイル両方にログを記録するよう設定
- 日次ローテーション機能を実装

## 実装内容
- `BroadcastLogger` を使用してSTDOUTとファイル両方に出力
- `/logs/production.log` に日次ローテーションで記録
- `.gitignore` でログファイルを除外設定
- ログディレクトリの `.keep` ファイルを追加

## 設定詳細
- ファイルローテーション: 日次
- ログレベル: INFO
- 出力先: STDOUT + `/logs/production.log`
- フォーマット: Rails標準フォーマット

🤖 Generated with [Claude Code](https://claude.ai/code)