### PR TITLE
feat: 本番環境でwebとjobsコンテナの個別ログファイル出力

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,9 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Log to both file and STDOUT for production
-  file_logger = Logger.new(Rails.root.join("logs", "production.log"), "daily")
+  # コンテナごとに別々のログファイルを使用
+  log_file_name = ENV.fetch("RAILS_LOG_FILE", "production.log")
+  file_logger = Logger.new(Rails.root.join("logs", log_file_name), "daily")
   file_logger.formatter = Logger::Formatter.new
 
   stdout_logger = Logger.new(STDOUT)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,6 +28,7 @@ services:
       - RAILS_ENV=production
       - RAILS_SERVE_STATIC_FILES=true
       - RAILS_LOG_TO_STDOUT=true
+      - RAILS_LOG_FILE=production-web.log
       - TZ=Asia/Tokyo
       - GIT_COMMIT=${GIT_COMMIT}
 
@@ -85,6 +86,7 @@ services:
     # 追加の環境変数
     environment:
       - RAILS_ENV=production
+      - RAILS_LOG_FILE=production-jobs.log
       - SOLID_QUEUE_LOG_LEVEL=info
       - TZ=Asia/Tokyo
       - GIT_COMMIT=${GIT_COMMIT}


### PR DESCRIPTION
## 概要
本番環境でwebコンテナとjobsコンテナが個別のログファイルに出力するよう改善

## 変更内容
- `RAILS_LOG_FILE`環境変数でログファイル名を制御可能に
- webコンテナ: `production-web.log`に出力
- jobsコンテナ: `production-jobs.log`に出力
- 両コンテナとも引き続きSTDOUTにも出力（Docker logs対応）

## 解決する問題
- 複数コンテナが同一ログファイルに書き込むことによるファイルロック競合
- webとjobsのログが混在してデバッグが困難

## テスト計画
- [ ] 本番環境でwebコンテナのログが`/logs/production-web.log`に出力される
- [ ] 本番環境でjobsコンテナのログが`/logs/production-jobs.log`に出力される
- [ ] 両コンテナともSTDOUTへの出力が継続される

🤖 Generated with [Claude Code](https://claude.ai/code)