### PR TITLE
fix: WebAuthn verifyメソッドのパラメータ修正

### DIFF
--- a/app/services/webauthn_service.rb
+++ b/app/services/webauthn_service.rb
@@ -77,12 +77,8 @@ class WebauthnService
       # WebAuthn 3.4.1の正しいAPIを使用
       webauthn_credential = WebAuthn::Credential.from_create(credential_response)
 
-      # 検証を実行（必要なパラメータを明示的に指定）
-      webauthn_credential.verify(
-        challenge,
-        rp_id: rp_id,
-        origin: origin
-      )
+      # 検証を実行（設定されたRP IDとOriginを使用）
+      webauthn_credential.verify(challenge)
 
       # データベースに保存
       user.webauthn_credentials.create!(
@@ -131,13 +127,11 @@ class WebauthnService
       # WebAuthn 3.4.1の正しいAPIを使用
       webauthn_credential = WebAuthn::Credential.from_get(credential_response)
 
-      # 検証を実行（必要なパラメータを明示的に指定）
+      # 検証を実行（設定されたRP IDとOriginを使用）
       webauthn_credential.verify(
         challenge,
         public_key: stored_credential.public_key,
-        sign_count: stored_credential.sign_count,
-        rp_id: rp_id,
-        origin: origin
+        sign_count: stored_credential.sign_count
       )
 
       # 成功した場合、使用履歴を更新


### PR DESCRIPTION
## Summary
- WebAuthn 3.4.1のverifyメソッドAPIを正しい形式に修正
- unknown keywords: :rp_id, :origin エラーを解決

## Problem
本番環境でWebAuthn登録時に以下のエラーが発生：
```
WebAuthn registration error: unknown keywords: :rp_id, :origin
```

## Technical Changes
### WebAuthn API Fix
- WebAuthn 3.4.1では`rp_id`と`origin`パラメータは`verify`メソッドで直接指定不可
- 設定ファイル(`config/initializers/webauthn.rb`)で指定されたRP IDとOriginが自動使用される
- 登録時: `webauthn_credential.verify(challenge)` のみ
- 認証時: `public_key`と`sign_count`パラメータのみ保持

## Environment Variables Required
本番環境で以下の環境変数設定が必要：
```bash
WEBAUTHN_RP_ID=kty.at
WEBAUTHN_ORIGIN=https://app.kty.at
```

## Test plan
- [x] WebAuthn 3.4.1のAPIドキュメントを確認
- [x] verifyメソッドから不要なパラメータを削除
- [x] 設定ファイルでのRP ID/Origin自動使用を確認

🤖 Generated with [Claude Code](https://claude.ai/code)