### PR TITLE
fix: WebAuthn設定にrp_id設定を追加

### DIFF
--- a/config/initializers/webauthn.rb
+++ b/config/initializers/webauthn.rb
@@ -10,6 +10,7 @@ WebAuthn.configure do |config|
 
   # デフォルトのRP（Relying Party）設定
   config.rp_name = Settings.webauthn.rp_name
+  config.rp_id = Settings.webauthn.rp_id
 
   # Origin設定 (3.4.1では allowed_origins を使用)
   config.allowed_origins = [ Settings.webauthn.origin ]


### PR DESCRIPTION
## Summary
- WebAuthn設定にrp_id設定を追加
- WebAuthn::RpIdVerificationErrorを解決

## Problem
本番環境でWebAuthn登録時に`WebAuthn::RpIdVerificationError`が発生していました。

## Root Cause
WebAuthn 3.4.1の設定で`config.rp_id`が欠落していました。
Origin: `https://app.kty.at` に対して、RP IDが適切に設定されていませんでした。

## Technical Changes
### WebAuthn Initializer Fix
- `config/initializers/webauthn.rb`に`config.rp_id = Settings.webauthn.rp_id`を追加
- 環境変数`WEBAUTHN_RP_ID=kty.at`の値が正しく設定に反映される

## Environment Variables Required
本番環境で以下の環境変数設定が必要：
```bash
WEBAUTHN_RP_ID=kty.at
WEBAUTHN_ORIGIN=https://app.kty.at
```

## Test plan
- [x] WebAuthn設定にrp_id設定を追加
- [x] 環境変数からの値取得を確認
- [x] RP ID検証エラーの解決を確認

🤖 Generated with [Claude Code](https://claude.ai/code)