### PR TITLE
fix: WebAuthn認証時にrpIdパラメータを追加

### DIFF
--- a/app/javascript/controllers/webauthn_controller.js
+++ b/app/javascript/controllers/webauthn_controller.js
@@ -193,7 +193,8 @@ export default class extends Controller {
       challenge: challenge,
       allowCredentials: allowCredentials,
       timeout: options.timeout,
-      userVerification: options.userVerification
+      userVerification: options.userVerification,
+      rpId: options.rpId
     }
     
     console.log('Get options:', getOptions)


### PR DESCRIPTION
## Summary
- WebAuthn認証時のJavaScriptでrpIdパラメータを明示的に指定
- NotAllowedErrorの根本原因を解決

## Problem
WebAuthn認証時に`NotAllowedError`が発生していました。調査の結果、JavaScript側で`navigator.credentials.get()`にrpIdパラメータが指定されていないことが原因と判明しました。

## Root Cause
```javascript
// Before: rpIdが指定されていない
const getOptions = {
  challenge: challenge,
  allowCredentials: allowCredentials,
  timeout: options.timeout,
  userVerification: options.userVerification
}

// After: rpIdを明示的に指定
const getOptions = {
  challenge: challenge,
  allowCredentials: allowCredentials,
  timeout: options.timeout,
  userVerification: options.userVerification,
  rpId: options.rpId  // ← 追加
}
```

## Technical Changes
### WebAuthn Controller JS Fix
- `navigator.credentials.get()`でrpIdパラメータを追加
- サーバーから送信されるrpId設定値がブラウザに正しく渡される
- 登録時と認証時で同じRP IDが使用される

## Expected Benefits
- WebAuthn認証で`NotAllowedError`が解消される
- 新規登録されたセキュリティキーでのログインが正常に動作
- RP ID変更後の認証が正しく機能する

## Test plan
- [x] WebAuthn 3.4.1のAPI仕様を確認
- [x] JavaScript側でrpIdパラメータを追加
- [x] 認証時に正しいRP IDが送信されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)