### PR TITLE
Fix WebAuthn authentication rpId parameter

### DIFF
--- a/app/services/webauthn_service.rb
+++ b/app/services/webauthn_service.rb
@@ -60,8 +60,10 @@ class WebauthnService
         timeout: Settings.webauthn.timeout
       )
 
-      # Rails controllerでJSONレンダリング可能な形式で返す
-      options.as_json
+      # rpIdを明示的に追加
+      result = options.as_json
+      result["rpId"] = rp_id
+      result
     end
 
     # クレデンシャルを登録

--- a/spec/services/webauthn_service_spec.rb
+++ b/spec/services/webauthn_service_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe WebauthnService, type: :service do
 
       result = described_class.authentication_options(user)
 
-      expect(result).to eq(mock_options)
+      expected_result = mock_options.merge('rpId' => 'localhost')
+      expect(result).to eq(expected_result)
       expect(WebAuthn::Credential).to have_received(:options_for_get)
     end
   end


### PR DESCRIPTION
## Summary
- WebAuthn認証時のNotAllowedErrorを修正
- 認証オプションにrpIdを明示的に追加

## Test plan
- [ ] 本番環境でセキュリティキー認証をテスト
- [ ] WEBAUTHN_RP_ID環境変数が正しく設定されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)